### PR TITLE
Feature:  State Observable Extensions Implementation

### DIFF
--- a/lib/extensions/state_observable_extensions.dart
+++ b/lib/extensions/state_observable_extensions.dart
@@ -38,3 +38,31 @@ extension ObservableValueNotifier<T> on ValueNotifier<T> {
     return streamController.stream;
   }
 }
+
+extension ReactiveInt on int {
+  /// Create a reactive class from primitive int
+  ///
+  /// example: 0.obs()
+  StateObservable<int> obs() => StateObservable<int>(this);
+}
+
+extension ReactiveDouble on double {
+  /// Create a reactive class from primitive double
+  /// 
+  /// example: 0.0.obs()
+  StateObservable<double> obs() => StateObservable<double>(this);
+}
+
+extension ReactiveString on String {
+  /// Create a reactive class from  String
+  /// 
+  /// example: 'Hello'.obs()
+  StateObservable<String> obs() => StateObservable<String>(this);
+}
+
+extension ReactiveBool on bool {
+  /// Create a reactive class from primitive boolean
+  /// 
+  /// example: false.obs()
+  StateObservable<bool> obs() => StateObservable(this);
+}

--- a/test/reactive_primitive_test.dart
+++ b/test/reactive_primitive_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_deep_state_manage/extensions/state_observable_extensions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Testing reactive primitive', () {
+    test('Should test the reactive [int]', () {
+      //arrange
+      bool isCallbackExecuted = false;
+      final observableInt = 0.obs();
+
+      //act
+      observableInt.addListener(() {
+        isCallbackExecuted = true;
+      });
+      observableInt.state++;
+
+      //assert
+      expect(observableInt.state, 1);
+      expect(isCallbackExecuted, true);
+    });
+
+    test('Should test the reactive [double]', () {
+      //arrange
+      bool isCallbackExecuted = false;
+      final observableDouble = 0.0.obs();
+
+      //act
+      observableDouble.addListener(() {
+        isCallbackExecuted = true;
+      });
+        observableDouble.state += 1.25;
+
+      //assert
+      expect(observableDouble.state, 1.25);
+      expect(isCallbackExecuted, true);
+    });
+
+    test('Should test the reactive [String]', () {
+      //arrange
+      bool isCallbackExecuted = false;
+      final observableString = 'Hello'.obs();
+
+      //act
+      observableString.addListener((){
+        isCallbackExecuted = true;
+      });
+      observableString.state += ' World!';
+
+      //assert
+      expect(observableString.state, 'Hello World!');
+      expect(isCallbackExecuted, true);
+    });
+
+    test('Should test reactive [bool]', () {
+      //arrange
+      bool isCallbackExecuted = false;
+      final observableBool = false.obs();
+
+      //act
+      observableBool.addListener(() {
+        isCallbackExecuted = true;
+      });
+      observableBool.state = true;
+
+      //assert
+      expect(observableBool.state, true);
+      expect(isCallbackExecuted, true);
+    });
+  });
+}


### PR DESCRIPTION
## Overview
Adding reactive extensions for primitive types with corresponding test coverage.

## Changes Added
- Reactive extensions for primitive types (int, double, String, bool) 
- Test suite for reactive primitive behavior

## Implementation Details
- Added extension methods to convert primitives to StateObservable instances
- Each extension provides an `obs()` method for reactive state creation
- Added documentation with usage examples for each extension
- Implemented type-safe conversions with explicit generic types

## Testing Details
- Added unit tests for each primitive type conversion

## Breaking Changes
None. Added functionality is purely additive.